### PR TITLE
Fix matplotlib backend initialization

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,6 +1,7 @@
+import matplotlib
+matplotlib.use('Agg')
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
-import matplotlib
 from io import BytesIO
 import sqlite3
 import base64
@@ -8,7 +9,6 @@ from config import Config
 from datetime import datetime, timedelta
 import matplotlib.dates as mdates
 from matplotlib.dates import date2num
-matplotlib.use('agg')
 
 
 def graph_db_data(sensor_type):


### PR DESCRIPTION
## Summary
- ensure graph uses the Agg backend before importing pyplot

## Testing
- `python -m py_compile graph.py`
- `python -m py_compile device_control.py app.py routes.py utils.py cron_manager.py wiz_manager.py models.py log_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6840613e3668832e89937159bb6360bc